### PR TITLE
docs: add COPILOT_TOKEN verification log

### DIFF
--- a/.github/COPILOT-SETUP.md
+++ b/.github/COPILOT-SETUP.md
@@ -59,3 +59,9 @@ integration policy. The fix:
    - `~/.bashrc` and `~/.profile` — for the agent's interactive bash sessions (which start fresh and don't inherit `$GITHUB_ENV`)
 
    This ensures the agent's `gh` commands use the PAT.
+
+## Verification Log
+
+| Date | Verified By | Result |
+|------|------------|--------|
+| 2026-03-23 | copilot/create-test-pr | ✅ COPILOT_TOKEN readable; PR creation successful |


### PR DESCRIPTION
## Problem
Verify that COPILOT_TOKEN is accessible to the Copilot agent session and that the full PR creation chain works end-to-end.

## Change
Added a Verification Log section to `.github/COPILOT-SETUP.md` recording the 2026-03-23 successful COPILOT_TOKEN test.

## Verification
- `GH_TOKEN` confirmed set in agent session (prefix: `ghp_m4obwQ...`, sourced from `COPILOT_TOKEN` secret via copilot-setup-steps.yml)
- Changes pushed successfully via `report_progress` (authenticated with GH_TOKEN)
- This PR itself is the final verification of the full PR creation chain
