### PR TITLE
ci: defer PR Validation to only run after final commit (draft PR workflow)

### DIFF
--- a/.github/skills/coding-agent-workflow/SKILL.md
+++ b/.github/skills/coding-agent-workflow/SKILL.md
@@ -74,25 +74,37 @@ This skill is automatically loaded by all coding agents. It defines the core wor
 
 4a. **Watch PR Validation and Fix Failures (primary agent only)**:
 
-   After every `report_progress` call that pushes code changes, load and follow the
-   **`watch-pr-validation`** skill. This skill covers the complete loop:
+   PR Validation only runs on **non-draft** PRs. It is triggered when you call
+   `scripts/pr-github.sh mark-ready` (step 4b) to convert the draft to ready-for-review.
+
+   After calling `mark-ready`, load and follow the **`watch-pr-validation`** skill:
 
    - Find the automatically-triggered PR Validation run for your branch
    - Watch it until completion
    - If it **fails**: read the error logs, fix the issues, re-run `pre-push-validation`
-     locally, call `report_progress` again, and repeat
+     locally, call `report_progress` again (PR stays ready, new commit triggers validation again), and repeat
    - Only proceed to the next step once CI is **green**
 
    **Do not hand off to the next agent with a failing build.**
 
-4b. **Create the Pull Request (primary agent only)**:
+4b. **Create the Pull Request and Trigger Validation (primary agent only)**:
 
-   Once CI is green, use the **`create-pr-github`** skill to open the PR. The agent is
+   Once all work is committed and pushed via `report_progress`, use the **`create-pr-github`** skill to open the PR. The agent is
    responsible for creating the PR — do not wait for the user to click "Create Pull Request"
    in the GitHub UI.
 
    - Check first that no open PR already exists for this branch
    - Use the standard PR body template (Problem / Change / Verification)
+   - PRs are created as **drafts** — PR Validation does NOT run on draft PRs
+   - After creating the draft PR, call `scripts/pr-github.sh mark-ready` to convert it to
+     ready-for-review. This is the **single trigger** for PR Validation and ensures the
+     pipeline only runs once the work is complete.
+
+   ```bash
+   # After report_progress has pushed all commits:
+   echo "..." | scripts/pr-github.sh create --title "feat: ..." --body-from-stdin
+   scripts/pr-github.sh mark-ready
+   ```
 
 5. **Create Summary Comment (After PR Created)**: Post a PR comment with:
    - **Summary**: Brief description of what you completed
@@ -120,7 +132,8 @@ This skill is automatically loaded by all coding agents. It defines the core wor
 ## Key Principles
 
 - **GitHub creates branches automatically** - never attempt to create or switch branches yourself
-- **Agent creates PRs** - after pushing and CI is green, always use the `create-pr-github` skill to open the PR; do NOT wait for the user to click "Create Pull Request" in the GitHub UI
+- **Agent creates draft PRs** - after pushing all work with `report_progress`, use the `create-pr-github` skill to create a **draft** PR; do NOT wait for the user to click "Create Pull Request" in the GitHub UI
+- **Always call `mark-ready` after creating the PR** - run `scripts/pr-github.sh mark-ready` to convert the draft to ready-for-review; this is the single trigger for PR Validation
 - **Never create a duplicate PR** - check if one already exists for your branch before creating
 - **`report_progress` is only available to the primary agent** - subagents spawned via `task` tool must use `git commit` instead
 - **Always use `report_progress`** for commits and pushes (primary agent) - never use manual `git push` commands

--- a/.github/skills/create-pr-github/SKILL.md
+++ b/.github/skills/create-pr-github/SKILL.md
@@ -9,6 +9,10 @@ compatibility: Preferred: scripts/pr-github.sh wrapper. Fallback: git + GitHub C
 ## Purpose
 Create a GitHub pull request in a consistent, policy-compliant way, and include the repo's preferred merge method guidance (rebase and merge).
 
+PRs are created as **drafts** to avoid triggering PR Validation before work is complete.
+Once all commits are pushed, call `scripts/pr-github.sh mark-ready` to convert the draft
+to ready-for-review — this is the single trigger for PR Validation.
+
 **Priority order:**
 1. **FIRST**: Use `scripts/pr-github.sh` wrapper script (designed for permanent approval)
 2. **SECOND**: Use GitHub MCP tools (if available and wrapper doesn't fit)
@@ -22,6 +26,7 @@ Create a GitHub pull request in a consistent, policy-compliant way, and include 
 - Before creating the PR, post the **exact Title and Description** in chat
 - Use the standard PR body template (Problem / Change / Verification / Screenshots)
 - Use **Rebase and merge** for merging PRs to maintain a linear history (see `CONTRIBUTING.md`)
+- Call `scripts/pr-github.sh mark-ready` after creating the PR to trigger PR Validation
 
 ### Must Not
 - Create PRs from `main`
@@ -63,15 +68,15 @@ scripts/git-status.sh --short
 git push -u origin HEAD
 ```
 
-### 3. Create the PR
+### 3. Create the PR (as Draft)
 
 #### Preferred: Wrapper Script
-Create a PR:
+Create a draft PR:
 ```bash
 echo "## Summary\n\nPR description" | scripts/pr-github.sh create --title "<type(scope): summary>" --body-from-stdin
 ```
 
-Create and merge (only when explicitly requested):
+Create and merge (only when explicitly requested — skips draft; use for release/internal PRs):
 ```bash
 echo "## Summary\n\nPR description" | scripts/pr-github.sh create-and-merge --title "<type(scope): summary>" --body-from-stdin
 ```
@@ -82,18 +87,36 @@ echo "## Summary\n\nPR description" | PAGER=cat gh pr create \
   --base main \
   --head "$(git branch --show-current)" \
   --title "<type(scope): summary>" \
-  --body-file -
+  --body-file - \
+  --draft
 ```
 
-### 4. Merge (Only When Explicitly Requested)
+### 4. Mark PR as Ready (Triggers PR Validation)
+
+After creating the draft PR, convert it to ready-for-review. This is what triggers the
+PR Validation pipeline — **do not skip this step**.
+
+#### Preferred: Wrapper Script
+```bash
+scripts/pr-github.sh mark-ready
+```
+
+#### Fallback: `gh` CLI
+```bash
+PAGER=cat gh pr ready <pr-number>
+```
+
+### 5. Merge (Only When Explicitly Requested)
 This repository requires **rebase and merge**.
+
+Wait for PR Validation to pass (green ✅) before merging.
 
 #### Preferred: Wrapper Script
 ```bash
 scripts/pr-github.sh merge <pr-number>
 ```
 
-Or combined create-and-merge:
+Or combined create-and-merge (non-draft, for release/internal PRs only):
 ```bash
 echo "## Summary\n\nPR description" | scripts/pr-github.sh create-and-merge --title "<type(scope): summary>" --body-from-stdin
 ```
@@ -103,7 +126,7 @@ echo "## Summary\n\nPR description" | scripts/pr-github.sh create-and-merge --ti
 PAGER=cat gh pr merge <pr-number> --rebase --delete-branch
 ```
 
-### 5. If Rebase-Merge Is Blocked (Conflicts)
+### 6. If Rebase-Merge Is Blocked (Conflicts)
 ```bash
 git pull --rebase origin main
 # resolve conflicts

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -3,6 +3,7 @@ name: PR Validation
 on:
   pull_request:
     branches: [main]
+    types: [ready_for_review, synchronize, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -18,6 +19,7 @@ jobs:
   docker:
     name: Build & Push Docker Image for UAT
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
 
     steps:
       - name: Checkout

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -63,11 +63,13 @@ If these appear as **transitive dependencies** (pulled in by another package), u
 
 | Workflow | File | Trigger | Purpose |
 |----------|------|---------|---------|
-| PR Validation | `pr-validation.yml` | Pull requests to `main` | Lint, type check, test, `next build`, markdown lint |
+| PR Validation | `pr-validation.yml` | Non-draft PRs to `main` (ready for review, synchronize, reopened) | Lint, type check, test, `next build`, markdown lint |
 | CI | `ci.yml` | Push to `main` | Run `commit-and-tag-version` to bump version and create tag |
 | Release | `release.yml` | Version tags (`v*`) | Create GitHub Release, build and push Docker image to GHCR |
 
 **Test Optimization:** Tests only run in PR Validation workflow to eliminate redundancy. CI workflow focuses solely on versioning after merge.
+
+**Draft PR Workflow:** Coding agents create PRs as **drafts** so that PR Validation does not run on intermediate commits. PR Validation is triggered exactly once per work session by calling `scripts/pr-github.sh mark-ready` (which converts the draft to ready-for-review) only after all work is complete.
 
 **Commit Guardrails:** Pull requests that only change workflow/internal tooling (e.g., `.github/`, `scripts/`, `docs/`) must not use version-bumping Conventional Commit types such as `feat:` or `fix:`. Use `chore:`, `docs:`, `ci:` instead.
 

--- a/scripts/pr-github.sh
+++ b/scripts/pr-github.sh
@@ -13,6 +13,8 @@ Usage:
 
   scripts/pr-github.sh create-and-merge --title <title> --body-from-stdin
 
+  scripts/pr-github.sh mark-ready [<pr-number>]
+
 Options:
   --title <title>         PR title (use Conventional Commits style)
   --body-from-stdin       Read PR body from stdin
@@ -20,7 +22,9 @@ Options:
 Notes:
   - Required: provide an explicit title + body via stdin (agent-authored description)
   - This script intentionally does not guess title/body
-  - **Agent guidance:** This script is the **authoritative** repo tool for creating and merging PRs. Use `scripts/pr-github.sh create` to create PRs and `scripts/pr-github.sh create-and-merge` to merge them (rebase + delete branch). Body must be piped via stdin.
+  - PRs are created as **drafts** by default. Call `mark-ready` when all work is
+    complete — this converts the draft to ready-for-review and triggers PR Validation.
+  - **Agent guidance:** This script is the **authoritative** repo tool for creating and merging PRs. Use `scripts/pr-github.sh create` to create PRs (as draft) and `scripts/pr-github.sh mark-ready` to trigger PR Validation. Use `scripts/pr-github.sh create-and-merge` to merge them (rebase + delete branch). Body must be piped via stdin.
   - **Fallback:** Use GitHub chat tools (`github/*`) only when the script does not support a necessary advanced operation or for quick inspection of checks.
   - Requires: git + GitHub CLI (gh) authenticated when used as a CLI fallback
   - Merge policy: uses rebase-and-merge for linear history (per CONTRIBUTING.md)
@@ -107,6 +111,7 @@ parse_args() {
 }
 
 ensure_pr_exists() {
+  local use_draft="${1:-true}"
   local branch
   branch="$(git branch --show-current)"
 
@@ -118,10 +123,15 @@ ensure_pr_exists() {
     return 0
   fi
 
-  echo "No open PR found for branch '$branch'; creating..." >&2
   require_non_empty "$TITLE" "PR title"
   require_non_empty "$BODY_TEXT" "PR body"
-  echo "$BODY_TEXT" | gh_safe pr create --base main --head "$branch" --title "$TITLE" --body-file -
+  if [[ "$use_draft" == "true" ]]; then
+    echo "No open PR found for branch '$branch'; creating draft PR..." >&2
+    echo "$BODY_TEXT" | gh_safe pr create --base main --head "$branch" --title "$TITLE" --body-file - --draft
+  else
+    echo "No open PR found for branch '$branch'; creating PR..." >&2
+    echo "$BODY_TEXT" | gh_safe pr create --base main --head "$branch" --title "$TITLE" --body-file -
+  fi
 }
 
 get_pr_number() {
@@ -140,6 +150,20 @@ get_pr_number() {
   gh_safe pr view --json number -q '.number'
 }
 
+# Same as get_pr_number but exits with an error if no open PR is found (used by mark-ready).
+get_pr_number_for_branch() {
+  local branch
+  branch="$(git branch --show-current)"
+
+  local open_pr_number
+  open_pr_number="$(gh_safe pr list --head "$branch" --state open --json number -q '.[0].number' 2>/dev/null || true)"
+  if [[ -z "${open_pr_number//[[:space:]]/}" ]]; then
+    echo "Error: no open PR found for branch '$branch'. Create one first with 'scripts/pr-github.sh create'." >&2
+    exit 2
+  fi
+  echo "$open_pr_number"
+}
+
 main() {
   if [[ $# -lt 1 ]]; then
     usage
@@ -152,6 +176,26 @@ main() {
 
   case "$cmd" in
     create|create-and-merge)
+      ;;
+    mark-ready)
+      require_not_main
+      if ! command -v gh >/dev/null 2>&1; then
+        echo "Error: gh is not installed." >&2
+        exit 2
+      fi
+      if ! gh auth status >/dev/null 2>&1; then
+        echo "Error: gh is not authenticated. Run: gh auth login" >&2
+        exit 2
+      fi
+      local pr_arg="${1:-}"
+      if [[ -z "$pr_arg" ]]; then
+        pr_arg="$(get_pr_number_for_branch)"
+      fi
+      require_non_empty "$pr_arg" "PR number"
+      echo "Converting PR #${pr_arg} from draft to ready for review..." >&2
+      gh_safe pr ready "$pr_arg"
+      echo "✓ PR #${pr_arg} is now ready for review — PR Validation will trigger." >&2
+      return 0
       ;;
     *)
       echo "Error: unknown command: $cmd" >&2
@@ -188,7 +232,11 @@ main() {
     git push -u origin HEAD
   fi
 
-  ensure_pr_exists
+  local use_draft="true"
+  if [[ "$cmd" == "create-and-merge" ]]; then
+    use_draft="false"
+  fi
+  ensure_pr_exists "$use_draft"
 
   local pr
   pr="$(get_pr_number)"


### PR DESCRIPTION
## Problem
PR Validation pipeline was triggering on every intermediate commit pushed by the Copilot coding agent (initial plan commit, progress commits), wasting CI resources before any real work was done.

## Change
- `pr-validation.yml`: Added `ready_for_review`, `synchronize`, `reopened` as explicit trigger types; added `if: github.event.pull_request.draft == false` guard on the `docker` job — the pipeline is now skipped entirely for draft PRs.
- `scripts/pr-github.sh`: `create` command now creates PRs as `--draft` by default. New `mark-ready` subcommand calls `gh pr ready` to convert a draft PR to ready-for-review, which becomes the single trigger for PR Validation. `create-and-merge` still creates non-draft PRs (for release/internal use cases).
- `create-pr-github` skill: Updated to document the draft PR flow and the mandatory `mark-ready` step.
- `coding-agent-workflow` skill: Updated step 4a/4b to reflect that validation only runs after `mark-ready`.
- `docs/conventions.md`: Updated the workflow table and added a note explaining the draft PR pattern.

## Verification
- `bash -n scripts/pr-github.sh` syntax check passes
- CodeQL security scan: 0 alerts
- Code review feedback addressed
