### PR TITLE
docs: add Required Agents table to work-protocol template and feature 001

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -499,6 +499,17 @@ The first agent in the workflow creates `work-protocol.md` using this template:
 **Workflow Type:** Feature / Bug Fix / Workflow
 **Created:** YYYY-MM-DD
 
+## Required Agents
+
+<!-- List required agents for this workflow type. Update Status to ✅ Complete as each agent logs their work below. -->
+<!-- Feature agents: Requirements Engineer, Architect, Quality Engineer, Task Planner, Developer, Technical Writer, Code Reviewer, UAT Tester (if user-facing), Release Manager, Retrospective -->
+<!-- Bug Fix agents: Issue Analyst, Developer, Technical Writer, Code Reviewer, UAT Tester (if needed), Release Manager, Retrospective -->
+<!-- Workflow agents: Workflow Engineer, Release Manager -->
+
+| Agent | Status |
+|-------|--------|
+| <Agent Name> | ⬜ Pending |
+
 ## Agent Work Log
 
 <!-- Each agent appends their entry below when they complete their work. -->

--- a/docs/features/001-check-report-conformity/work-protocol.md
+++ b/docs/features/001-check-report-conformity/work-protocol.md
@@ -5,6 +5,21 @@
 **Workflow Type:** Feature
 **Created:** 2025-01-28
 
+## Required Agents
+
+| Agent | Status |
+|-------|--------|
+| Requirements Engineer | ✅ Complete |
+| Architect | ✅ Complete |
+| Quality Engineer | ⬜ Pending |
+| Task Planner | ⬜ Pending |
+| Developer | ⬜ Pending |
+| Technical Writer | ⬜ Pending |
+| Code Reviewer | ⬜ Pending |
+| UAT Tester | ⚠️ Required (user-facing feature) |
+| Release Manager | ⬜ Pending |
+| Retrospective | ⬜ Pending |
+
 ## Agent Work Log
 
 <!-- Each agent appends their entry below when they complete their work. -->


### PR DESCRIPTION
## Problem
The `docs/agents.md` artifact description for Work Protocol states the document should contain a "Required Agents table (workflow-type dependent), Agent Work Log entries", but the template and existing `work-protocol.md` files only contained the Agent Work Log section — the Required Agents table was entirely missing.

## Change
- Updated the work-protocol template in `docs/agents.md` to include a `## Required Agents` section with a status-tracking table and inline comments listing which agents are required per workflow type (Feature / Bug Fix / Workflow).
- Updated `docs/features/001-check-report-conformity/work-protocol.md` to add the Required Agents section, reflecting the actual current state: Requirements Engineer and Architect are ✅ Complete; all remaining agents (Quality Engineer, Task Planner, Developer, Technical Writer, Code Reviewer, UAT Tester, Release Manager, Retrospective) are ⬜ Pending or ⚠️ Required.

## Verification
- The template in `docs/agents.md` now matches the artifact description: Required Agents table + Agent Work Log.
- The feature 001 work-protocol.md now shows clear tracking of which workflow steps are complete and which are pending.
- Documentation-only change; no executable code modified.
